### PR TITLE
Add directions for installing necessary binaries

### DIFF
--- a/BappDescription.html
+++ b/BappDescription.html
@@ -5,4 +5,6 @@ and modify them, and then reserialize them before sending on. In the case of the
 Scanner, the extension will leave messages deserialized, to enable Burp to 
 access the contents of deserialized objects (to identify error messages, etc.).</p>
 
-<p>This extension requires a Microsoft Windows environment.</p>
+<p>This extension requires a Microsoft Windows environment.  The NBFS.exe file
+must be downloaded from the executables directory on the github page linked below
+and placed in the Burp Suite installation folder. </p>


### PR DESCRIPTION
The directions in BApp store do not include information about installing a necessary binary file from the github repository. This adds the necessary setup instructions.